### PR TITLE
Version info

### DIFF
--- a/handlebars/partials/base/body.hbs
+++ b/handlebars/partials/base/body.hbs
@@ -4,8 +4,8 @@
 
 --}}
 <h1>{{info.title}}</h1>
+<p class="sw-info-version">Version: <span>{{info.version}}</span></p>
 <p>{{md info.description}}</p>
-<p>{{info.version}}</p>
 
 {{#if consumes}}
     <div id="sw-default-consumes" class="sw-default-value">

--- a/handlebars/partials/base/body.hbs
+++ b/handlebars/partials/base/body.hbs
@@ -5,6 +5,7 @@
 --}}
 <h1>{{info.title}}</h1>
 <p>{{md info.description}}</p>
+<p>{{info.version}}</p>
 
 {{#if consumes}}
     <div id="sw-default-consumes" class="sw-default-value">

--- a/less/theme.less
+++ b/less/theme.less
@@ -163,3 +163,11 @@ span.sw-default-value-header {
   font-weight: bold;
 }
 
+.sw-info-version {
+  font-weight: bold;
+  span {
+    font-family: monospace;
+    font-weight: normal;
+    font-size: 1.1em;
+  }
+}

--- a/test/info-object/info-object-spec.js
+++ b/test/info-object/info-object-spec.js
@@ -1,0 +1,33 @@
+/*!
+ * bootprint-swagger <https://github.com/nknapp/bootprint-swagger>
+ *
+ * Copyright (c) 2015 Nils Knappmeier.
+ * Released under the MIT license.
+ */
+
+/* global describe */
+/* global it */
+/* global before */
+var expect = require('chai').expect
+var core = require('../core')
+
+describe('The info object should', function () {
+  this.timeout(10000)
+  var context = {}
+  before(function () {
+    return core.run(require('./swagger.json'), __dirname, context)
+  })
+
+  it('cause to render a title in <h1>.', function () {
+    expect(context.$('div.container > h1').html()).to.contain('API title')
+  })
+
+  it('cause to render the API version.', function () {
+    expect(context.$('p.sw-info-version').text()).to.contain('Version:')
+    expect(context.$('p.sw-info-version > span').text()).to.contain('1.0.0')
+  })
+
+  it('cause to render a description.', function () {
+    expect(context.$('p.sw-info-version + p + p').html()).to.contain('Description is present.')
+  })
+})

--- a/test/info-object/swagger.json
+++ b/test/info-object/swagger.json
@@ -1,0 +1,19 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "description": "Description is present.",
+    "version": "1.0.0",
+    "title": "API title"
+  },
+  "paths": {
+    "/": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
The generated HTML omits the obligatory "version" property of the "info" object - quite an important one. This PR fixes that by putting the API version immediately below the title.

A default styling is also included.