### PR TITLE
Add baseUrl property to generated output body

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.idea
 *.iml
 node_modules
 target

--- a/handlebars/partials/base/body.hbs
+++ b/handlebars/partials/base/body.hbs
@@ -4,7 +4,7 @@
 
 --}}
 <h1>{{info.title}}</h1>
-<p class="sw-info-version">Version: <span>{{info.version}}</span></p>
+<p class="sw-info">{{#if basePath}}Base URL: <span class="sw-info-basePath">{{basePath}}</span>, {{/if}}Version: <span class="sw-info-version">{{info.version}}</span></p>
 <p>{{md info.description}}</p>
 
 {{#if consumes}}

--- a/less/theme.less
+++ b/less/theme.less
@@ -163,7 +163,7 @@ span.sw-default-value-header {
   font-weight: bold;
 }
 
-.sw-info-version {
+.sw-info {
   font-weight: bold;
   span {
     font-family: monospace;

--- a/test/info-object/info-object-spec.js
+++ b/test/info-object/info-object-spec.js
@@ -23,11 +23,16 @@ describe('The info object should', function () {
   })
 
   it('cause to render the API version.', function () {
-    expect(context.$('p.sw-info-version').text()).to.contain('Version:')
-    expect(context.$('p.sw-info-version > span').text()).to.contain('1.0.0')
+    expect(context.$('p.sw-info').text()).to.contain('Version:')
+    expect(context.$('p.sw-info > span.sw-info-version').text()).to.contain('1.0.0')
+  })
+
+  it('cause to render the Base URL.', function () {
+    expect(context.$('p.sw-info').text()).to.contain('Base URL:')
+    expect(context.$('p.sw-info > span.sw-info-basePath').text()).to.contain('/v1')
   })
 
   it('cause to render a description.', function () {
-    expect(context.$('p.sw-info-version + p + p').html()).to.contain('Description is present.')
+    expect(context.$('p.sw-info + p + p').html()).to.contain('Description is present.')
   })
 })

--- a/test/info-object/swagger.json
+++ b/test/info-object/swagger.json
@@ -5,6 +5,7 @@
     "version": "1.0.0",
     "title": "API title"
   },
+  "basePath": "/v1",
   "paths": {
     "/": {
       "get": {


### PR DESCRIPTION
Issue #53: 'Missing fields' raises concern that the generated output 
contains neither host nor basePath. This pull request adds basePath to 
the top of index.html, just before info.version.

Both the location of basePath and the continued absence of host were
inspired by the current format of Swagger UI (2.0), with basePath and
info.version colocated and host never being displayed.

https://github.com/bootprint/bootprint-openapi/issues/53