### PR TITLE
Fix misaligned request descriptions

### DIFF
--- a/handlebars/partials/swagger/request-body.hbs
+++ b/handlebars/partials/swagger/request-body.hbs
@@ -20,6 +20,8 @@
                     <div class="col-md-6">
                         <p>{{md description}}</p>
                     </div>
+                </div>
+                <div class="row">
                     <div class="col-md-6 sw-request-model">{{>swagger/model model=schema}}</div>
                 </div>
             {{/with}}


### PR DESCRIPTION
I've noticed that request descriptions are misaligned because they appear next to their descriptions, not below.
Not sure if this is a good change but it fixed the problem.