### PR TITLE
Prepare for 1.0 release

### DIFF
--- a/.thought/helpers.js
+++ b/.thought/helpers.js
@@ -1,9 +1,7 @@
-var Q = require('q')
-var qfs = require('q-io/fs')
-var deep = require("q-deep")
-var path = require("path")
-var _ = require("lodash")
-
+var qfs = require('m-io/fs')
+var deep = require('deep-aplus')(require('q').Promise)
+var path = require('path')
+var _ = require('lodash')
 
 module.exports = {
   /**
@@ -15,27 +13,27 @@ module.exports = {
    */
   credits: function (options, customizeOptions) {
     return qfs.listTree('.', function (filePath) {
-      var file = path.basename(filePath);
+      var file = path.basename(filePath)
       // Do not traverse into the node_modules directory
-      if (file === 'node_modules' || file === ".git") {
-        return null;
+      if (file === 'node_modules' || file === '.git') {
+        return null
       }
       // Collect all files "credits.md"
       if (file === 'credits.md.hbs') {
-        return true;
+        return true
       }
-      return false;
+      return false
     }).then(function (creditFiles) {
-      return deep(creditFiles.map(function(creditFile) {
-        console.log(creditFile);
-        var input = _.merge({},this,{
+      return deep(creditFiles.map(function (creditFile) {
+        console.log(creditFile)
+        var input = _.merge({}, this, {
           __dirname: path.dirname(creditFile),
           __filename: creditFile
-        });
-        return qfs.read(creditFile).then(function(contents) {
-          return customizeOptions.engine.compile(contents)(input);
         })
-      }));
+        return qfs.read(creditFile).then(function (contents) {
+          return customizeOptions.engine.compile(contents)(input)
+        })
+      }))
     })
   }
 }

--- a/.thought/preprocessor.js
+++ b/.thought/preprocessor.js
@@ -13,6 +13,9 @@ module.exports = function (input) {
     .registerEngine('less', {
       defaultConfig: {}, run: function () {}
     })
+    .registerEngine('uglify', {
+      defaultConfig: {}, run: function () {}
+    })
     .registerEngine('preprocessor', {
       defaultConfig: {}, run: function () {}
     })
@@ -58,7 +61,6 @@ var hbDocs = function (files) {
       }),
       'children': children
     }
-
   })
 }
 
@@ -71,7 +73,7 @@ function createPartialTree (currentFile, partials, visitedFiles) {
   if (visitedFiles[currentFile.name]) {
     return {
       label: '*' + currentFile.name + '*',
-      name: currentFile.name,
+      name: currentFile.name
     }
   }
   visitedFiles[currentFile.name] = true
@@ -102,7 +104,7 @@ function createPartialTree (currentFile, partials, visitedFiles) {
  */
 function chainOrUndefined (startObj, propertyChain) {
   var result = startObj
-  for (var i = 1; i < arguments.length;i++) {
+  for (var i = 1; i < arguments.length; i++) {
     if (_.isUndefined(result)) {
       return undefined
     }

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,8 @@ node_js:
   - "0.12"
   - "iojs"
   - "4"
-  - "5"
+  - "6"
+  - "7"
 before_script:
   - npm install standard
   - standard

--- a/handlebars-partials.md
+++ b/handlebars-partials.md
@@ -107,7 +107,7 @@ Uses the following partials:
 
 ## base/footer
 
-(<a href="https://github.com/bootprint/bootprint-base/blob/v0.7.3/handlebars/partials/base/footer.hbs">jump to source in <code>bootprint-base@0.7.3</code></a>)
+(<a href="https://github.com/bootprint/bootprint-base/blob/v1.0.0/handlebars/partials/base/footer.hbs">jump to source in <code>bootprint-base@1.0.0</code></a>)
 
 
 This partial is displayed at the bottom of the HTML-body.
@@ -123,7 +123,7 @@ the Bootprint-result.
 
 ## base/header
 
-(<a href="https://github.com/bootprint/bootprint-base/blob/v0.7.3/handlebars/partials/base/header.hbs">jump to source in <code>bootprint-base@0.7.3</code></a>)
+(<a href="https://github.com/bootprint/bootprint-base/blob/v1.0.0/handlebars/partials/base/header.hbs">jump to source in <code>bootprint-base@1.0.0</code></a>)
 
 
 This partial is displayed at the top of the HTML-body.
@@ -153,7 +153,7 @@ Renders the page title
 
 ## json-schema/additionalProperties
 
-(<a href="https://github.com/bootprint/bootprint-json-schema/blob/v0.8.6/handlebars/partials/json-schema/additionalProperties.hbs">jump to source in <code>bootprint-json-schema@0.8.6</code></a>)
+(<a href="https://github.com/bootprint/bootprint-json-schema/blob/v1.0.0/handlebars/partials/json-schema/additionalProperties.hbs">jump to source in <code>bootprint-json-schema@1.0.0</code></a>)
 
 
 Uses the following partials:
@@ -162,7 +162,7 @@ Uses the following partials:
 
 ## json-schema/allOf
 
-(<a href="https://github.com/bootprint/bootprint-json-schema/blob/v0.8.6/handlebars/partials/json-schema/allOf.hbs">jump to source in <code>bootprint-json-schema@0.8.6</code></a>)
+(<a href="https://github.com/bootprint/bootprint-json-schema/blob/v1.0.0/handlebars/partials/json-schema/allOf.hbs">jump to source in <code>bootprint-json-schema@1.0.0</code></a>)
 
 
 Uses the following partials:
@@ -171,7 +171,7 @@ Uses the following partials:
 
 ## json-schema/anyOf
 
-(<a href="https://github.com/bootprint/bootprint-json-schema/blob/v0.8.6/handlebars/partials/json-schema/anyOf.hbs">jump to source in <code>bootprint-json-schema@0.8.6</code></a>)
+(<a href="https://github.com/bootprint/bootprint-json-schema/blob/v1.0.0/handlebars/partials/json-schema/anyOf.hbs">jump to source in <code>bootprint-json-schema@1.0.0</code></a>)
 
 
 Uses the following partials:
@@ -180,7 +180,7 @@ Uses the following partials:
 
 ## json-schema/array-items
 
-(<a href="https://github.com/bootprint/bootprint-json-schema/blob/v0.8.6/handlebars/partials/json-schema/array-items.hbs">jump to source in <code>bootprint-json-schema@0.8.6</code></a>)
+(<a href="https://github.com/bootprint/bootprint-json-schema/blob/v1.0.0/handlebars/partials/json-schema/array-items.hbs">jump to source in <code>bootprint-json-schema@1.0.0</code></a>)
 
 
 Uses the following partials:
@@ -189,7 +189,7 @@ Uses the following partials:
 
 ## json-schema/body
 
-(<a href="https://github.com/bootprint/bootprint-json-schema/blob/v0.8.6/handlebars/partials/json-schema/body.hbs">jump to source in <code>bootprint-json-schema@0.8.6</code></a>)
+(<a href="https://github.com/bootprint/bootprint-json-schema/blob/v1.0.0/handlebars/partials/json-schema/body.hbs">jump to source in <code>bootprint-json-schema@1.0.0</code></a>)
 
 
 Uses the following partials:
@@ -201,7 +201,7 @@ Uses the following partials:
 
 ## json-schema/datatype
 
-(<a href="https://github.com/bootprint/bootprint-json-schema/blob/v0.8.6/handlebars/partials/json-schema/datatype.hbs">jump to source in <code>bootprint-json-schema@0.8.6</code></a>)
+(<a href="https://github.com/bootprint/bootprint-json-schema/blob/v1.0.0/handlebars/partials/json-schema/datatype.hbs">jump to source in <code>bootprint-json-schema@1.0.0</code></a>)
 
 
 Enum values
@@ -225,7 +225,7 @@ Default values (for non-enum types)
 
 ## json-schema/definitions
 
-(<a href="https://github.com/bootprint/bootprint-json-schema/blob/v0.8.6/handlebars/partials/json-schema/definitions.hbs">jump to source in <code>bootprint-json-schema@0.8.6</code></a>)
+(<a href="https://github.com/bootprint/bootprint-json-schema/blob/v1.0.0/handlebars/partials/json-schema/definitions.hbs">jump to source in <code>bootprint-json-schema@1.0.0</code></a>)
 
 
 Uses the following partials:
@@ -233,7 +233,7 @@ Uses the following partials:
 
 ## json-schema/main-panel
 
-(<a href="https://github.com/bootprint/bootprint-json-schema/blob/v0.8.6/handlebars/partials/json-schema/main-panel.hbs">jump to source in <code>bootprint-json-schema@0.8.6</code></a>)
+(<a href="https://github.com/bootprint/bootprint-json-schema/blob/v1.0.0/handlebars/partials/json-schema/main-panel.hbs">jump to source in <code>bootprint-json-schema@1.0.0</code></a>)
 
 
 Uses the following partials:
@@ -243,7 +243,7 @@ Uses the following partials:
 
 ## json-schema/properties
 
-(<a href="https://github.com/bootprint/bootprint-json-schema/blob/v0.8.6/handlebars/partials/json-schema/properties.hbs">jump to source in <code>bootprint-json-schema@0.8.6</code></a>)
+(<a href="https://github.com/bootprint/bootprint-json-schema/blob/v1.0.0/handlebars/partials/json-schema/properties.hbs">jump to source in <code>bootprint-json-schema@1.0.0</code></a>)
 
 
 Uses the following partials:
@@ -252,13 +252,13 @@ Uses the following partials:
 
 ## json-schema/reference
 
-(<a href="https://github.com/bootprint/bootprint-json-schema/blob/v0.8.6/handlebars/partials/json-schema/reference.hbs">jump to source in <code>bootprint-json-schema@0.8.6</code></a>)
+(<a href="https://github.com/bootprint/bootprint-json-schema/blob/v1.0.0/handlebars/partials/json-schema/reference.hbs">jump to source in <code>bootprint-json-schema@1.0.0</code></a>)
 
 
 
 ## json-schema/type-object
 
-(<a href="https://github.com/bootprint/bootprint-json-schema/blob/v0.8.6/handlebars/partials/json-schema/type-object.hbs">jump to source in <code>bootprint-json-schema@0.8.6</code></a>)
+(<a href="https://github.com/bootprint/bootprint-json-schema/blob/v1.0.0/handlebars/partials/json-schema/type-object.hbs">jump to source in <code>bootprint-json-schema@1.0.0</code></a>)
 
 
 Renders the properties of an `object`

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "license": "MIT",
   "scripts": {
     "preformat": "standard --version || npm -g install standard",
-    "format": "standard --format",
+    "format": "standard --fix",
     "pretest": "standard --version || npm -g install standard",
     "test": "mocha --recursive && standard",
     "thought": "thought run -a",
@@ -18,10 +18,11 @@
     "preversion": "npm run thoughtcheck"
   },
   "dependencies": {
-    "bootprint-json-schema": "<1.0.0",
+    "bootprint-json-schema": "^1.0.0",
     "highlight.js": "^8.9.1",
     "json-stable-stringify": "^1.0.1",
-    "lodash": "^3.9.3"
+    "lodash": "^3.9.3",
+    "m-io": "^0.3.1"
   },
   "repository": {
     "type": "git",
@@ -31,21 +32,24 @@
     "url": "https://github.com/bootprint/bootprint-openapi/issues"
   },
   "homepage": "https://github.com/bootprint/bootprint-openapi",
+  "peerDependencies": {
+    "bootprint": "^1.0.0"
+  },
   "devDependencies": {
-    "bootprint": "<1.0.0",
+    "bootprint": "^1.0.0",
     "chai": "^3.3.0",
     "chai-as-promised": "^5.1.0",
     "cheerio": "^0.19.0",
     "customize": "^0.6.0",
     "customize-engine-handlebars": "^0.5.2",
+    "deep-aplus": "^1.0.4",
     "find-package": "^1.0.0",
     "ghooks": "^1.0.3",
     "mocha": "^2.3.3",
     "multilang-apidocs": "^0.2.1",
     "q": "^1.4.1",
-    "q-deep": "^1.0.1",
-    "q-io": "^1.13.1",
-    "thoughtful-release": "^0.3.0"
+    "thoughtful-release": "^0.3.1",
+    "trace-and-clarify-if-possible": "^1.0.0"
   },
   "keywords": [
     "openapi-to-html",
@@ -54,7 +58,7 @@
   ],
   "config": {
     "ghooks": {
-      "pre-commit": "standard"
+      "pre-push": "standard && thoughtful precommit"
     }
   },
   "files": [

--- a/test/core.js
+++ b/test/core.js
@@ -4,7 +4,7 @@
  * Copyright (c) 2015 Nils Knappmeier.
  * Released under the MIT license.
  */
-var qfs = require('q-io/fs')
+var qfs = require('m-io/fs')
 var cheerio = require('cheerio')
 var path = require('path')
 

--- a/test/mocha.opts
+++ b/test/mocha.opts
@@ -1,0 +1,1 @@
+--require trace-and-clarify-if-possible


### PR DESCRIPTION
- Use "trace-and-clarify-if-possible" to run tests
- Update travis configuration
- Update "format"-scripts for new version of StandardJS
 - Use "standard" and "thoughtful precommit" as "pre push"-hook
   (for protected master-branch)
 - Use m-io/fs instead of q-io/fs
   (see https://github.com/nknapp/m-io#m-io for details)
- Bump bootprint-dependencies to current versions
- User deep-aplus instead of q-deep
- Apply current StandardJS code style