### PR TITLE
fix response definitions deep-linking

### DIFF
--- a/handlebars/partials/swagger/responseDefinitions.hbs
+++ b/handlebars/partials/swagger/responseDefinitions.hbs
@@ -6,7 +6,7 @@
 
 <dl id="sw-response-definitions">
     {{#each responses}}
-        <dt><a name="{{key}}"></a>{{@key}}</dt>
+        <dt><a name="/responses/{{@key}}"></a>{{@key}}</dt>
         <dd>
             {{> swagger/response response=.}}
         </dd>


### PR DESCRIPTION
This seems to remedy a small bug in the responseDefinitions partial.  Before this the name property of the anchors was empty, but it now seems to working as expected.