### PR TITLE
#92: Add support for deprecated attribute

### DIFF
--- a/handlebars/helpers.js
+++ b/handlebars/helpers.js
@@ -97,11 +97,11 @@ module.exports = {
     if (_.isObject(example)) {
       switch (mimeType) {
         case 'application/json':
-          example = require('json-stable-stringify')(example, {space: 4})
+          example = require('json-stable-stringify')(example, { space: 4 })
           break
         case 'application/xml':
           // TODO: This should actually convert the example to XML but I don't know how yet. "help wanted"
-          example = require('json-stable-stringify')(example, {space: 4})
+          example = require('json-stable-stringify')(example, { space: 4 })
           break
       }
     }

--- a/handlebars/partials/swagger/operation.hbs
+++ b/handlebars/partials/swagger/operation.hbs
@@ -5,7 +5,7 @@
     @param {string} method the http-method (GET, POST, DELETE, PUT, PATCH)
     @api public
 --}}
-<div id="operation-{{htmlId path}}-{{htmlId method}}" class="swagger--panel-operation-{{method}} panel">
+<div id="operation-{{htmlId path}}-{{htmlId method}}" class="swagger--panel-operation-{{method}}{{#if deprecated}} swagger--panel-operation-deprecated{{/if}} panel">
     <div class="panel-heading">
         <div class="operation-summary">{{md summary stripParagraph="true"}}</div>
         <h3 class="panel-title"><span class="operation-name">{{toUpperCase method}}</span> <strong>{{path}}</strong></h3>
@@ -17,6 +17,9 @@
         {{/if}}
     </div>
     <div class="panel-body">
+        {{#if deprecated}}
+          <section class="sw-operation-deprecated"></section>
+        {{/if}}
         <section class="sw-operation-description">
             {{md operation.description}}
         </section>

--- a/handlebars/partials/swagger/summary.hbs
+++ b/handlebars/partials/swagger/summary.hbs
@@ -17,12 +17,12 @@
         {{#eachSorted .}}
             <tr>
                 {{#if @first}}
-                    <td class="swagger--summary-path" rowspan="{{@length}}">
+                    <td class="swagger--summary-path{{#if deprecated}} swagger--summary-operation-deprecated{{/if}}" rowspan="{{@length}}">
                         <a href="#path-{{htmlId @../key}}">{{@../key}}</a>
                     </td>
                 {{/if}}
                 <td>
-                    <a href="#operation-{{htmlId @../key}}-{{htmlId @key}}">{{toUpperCase @key}}</a>
+                    <a href="#operation-{{htmlId @../key}}-{{htmlId @key}}"{{#if deprecated}} class="swagger--summary-operation-deprecated"{{/if}}>{{toUpperCase @key}}</a>
                 </td>
                 <td>
                     {{md summary}}

--- a/handlebars/partials/swagger/tags.hbs
+++ b/handlebars/partials/swagger/tags.hbs
@@ -20,7 +20,7 @@
         </thead>
         <tbody>
             {{#each operations}}
-            <tr>
+            <tr{{#if deprecated}} class="swagger--summary-operation-deprecated"{{/if}}>
                 <td><a href="#operation-{{htmlId path}}-{{htmlId method}}">{{toUpperCase method}} {{path}}</a></td>
                 <td>{{md summary}}</td>
             </tr>

--- a/less/theme.less
+++ b/less/theme.less
@@ -12,6 +12,11 @@
   }
 }
 
+.swagger--summary-operation-deprecated {
+  opacity: 0.6;
+  text-decoration: line-through;
+}
+
 // Draw a panel in a given color
 .swagger--panel-operation(@color) {
   .panel-variant(darken(@color,30%), @panel-default-text, @color, darken(@color, 30%));
@@ -25,10 +30,6 @@
 }
 
 // Panels
-.swagger--panel-operation-post {
-    .swagger--panel-operation(#e7f6ec);
-  }
-
 .swagger--panel {
   &-operation-get {
     .swagger--panel-operation(#e7f0f7);
@@ -42,6 +43,10 @@
     .swagger--panel-operation(#FCE9E3);
   }
 
+  &-operation-post {
+    .swagger--panel-operation(#e7f6ec);
+  }
+
   &-operation-options {
     .swagger--panel-operation(#e7f0f7);
   }
@@ -53,6 +58,17 @@
   &-operation-head {
     .swagger--panel-operation(#fcffcd);
   }
+  
+  &-operation-deprecated {
+    opacity: 0.6;
+    .panel-title strong {
+      text-decoration: line-through;
+    }
+  }
+}
+
+.sw-operation-deprecated {
+  .named-section(@msg-sw-section-operation-deprecated);
 }
 
 .sw-operation-description {

--- a/less/variables.less
+++ b/less/variables.less
@@ -3,6 +3,7 @@
 @msg-sw-description: "Description";
 
 @msg-sw-section-operation-description: @msg-sw-description;
+@msg-sw-section-operation-deprecated: "Warning: Operation is deprecated.";
 @msg-sw-section-request-params: "Request parameters";
 @msg-sw-section-request-body: "Request body";
 @msg-sw-section-responses: "Responses";

--- a/test/petstore/petstore-spec.js
+++ b/test/petstore/petstore-spec.js
@@ -27,12 +27,20 @@ describe('The petstore example', function () {
     expect(context.$(".swagger--summary a[href='#operation--pet-post']").text()).to.equal('POST /pet')
   })
 
+  it("should contain a deprecated summary item '/pet/findByTags'", function () {
+    expect(context.$(".swagger--summary .swagger--summary-operation-deprecated a[href='#operation--pet-findByTags-get']").text()).to.equal('GET /pet/findByTags')
+  })
+
   it("should contain an path item '/pet' with id 'path--pet'", function () {
     expect(context.$('#path--pet').length).to.equal(1)
   })
 
   it("should contain a tag-based summary for the tag 'pet'", function () {
     expect(context.$('#tag-pet').length).to.equal(1)
+  })
+
+  it("should contain a deprecated GET operation '/pet/findByTags'", function () {
+    expect(context.$('#operation--pet-findByTags-get.swagger--panel-operation-deprecated').length).to.equal(1)
   })
 
   function responseHeader () {

--- a/test/petstore/swagger.json
+++ b/test/petstore/swagger.json
@@ -230,7 +230,8 @@
               "read:pets"
             ]
           }
-        ]
+        ],
+        "deprecated": true
       }
     },
     "/pet/{petId}": {

--- a/test/response-string-example/response-string-example-spec.js
+++ b/test/response-string-example/response-string-example-spec.js
@@ -19,6 +19,6 @@ describe('The response string-examples fixture', function () {
   })
   it('should render the response examples', function () {
     expect(context.$('dd.sw-response-200 .sw-response-examples').text(),
-    'Examples consisting of only a string should not be JSON.stringified').not.to.match(/\\n/)
+      'Examples consisting of only a string should not be JSON.stringified').not.to.match(/\\n/)
   })
 })


### PR DESCRIPTION
Fixes issue #92. Operations are made semi-opaque and a line through
their paths are added. Inspiration was drawn from Swagger UI.

Issue #92: 'Add support for deprecated attribute'